### PR TITLE
FIX: Chopper cutting boundary didn't calculate properly

### DIFF
--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
@@ -403,7 +403,7 @@ public class TileChopper extends UpgradeableTileEntity {
 	}
 	
 	private void recalculateChoppingRange() {
-		int cuttingSideSize = CUTTING_EXTRA_RANGE +  (int)Math.ceil( (Math.sqrt(getCurrentUpgrades() + 1)-1)/2);
+		int cuttingSideSize = CUTTING_EXTRA_RANGE +  (int)Math.ceil( (Math.sqrt(getUpgrades() + 1)-1)/2);
 		maxCuttingX = this.xCoord + cuttingSideSize;
 		minCuttingX = this.xCoord - cuttingSideSize;
 		maxCuttingZ = this.zCoord + cuttingSideSize;


### PR DESCRIPTION
getCurrentUpgrades() returns always 0 at this point (and by logic, returns the amount of upgrades in the upgrade slot).

The proper method here is getUpgrades() which returns the amount of upgrades installed in the machine.
