### PR TITLE
Dev upgrades

### DIFF
--- a/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
+++ b/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
@@ -16,6 +16,8 @@ import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeRegistry;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -174,44 +176,20 @@ public class BaseBlock extends BlockContainer implements IDismantleable {
                 	items.add(itemstack);
                 }
             }
-            
-            //drop the other types of upgrades first
-            if (world.getTileEntity(x, y, z) instanceof UpgradeableTileEntity) {
-            	UpgradeableTileEntity tileMachine = (UpgradeableTileEntity)world.getTileEntity(x, y, z);
-            	if (tileMachine.hasCobbleUpgrade) {
-            		ItemStack cobbleGen = new ItemStack(PAItems.cobbleUpgrade);
-            		items.add(cobbleGen);
-            		tileMachine.hasCobbleUpgrade = false;
-            	}
-            	if (tileMachine.hasFillerUpgrade) {
-            		ItemStack fillerUpgrade = new ItemStack(PAItems.fillerUpgrade);
-            		items.add(fillerUpgrade);
-            		tileMachine.hasFillerUpgrade = false;
-            	}
-            	if (tileMachine.hasWitherUpgrade) {
-            		ItemStack wither = new ItemStack(PAItems.witherUpgrade);
-            		items.add(wither);
-            		tileMachine.hasWitherUpgrade = false;
-            	}
-            }
-            
-            //if entity is IUpgradeable, drop the upgrades
-            if (world.getTileEntity(x, y, z) instanceof IUpgradeable) {
-            	IUpgradeable tileMachine = (IUpgradeable)world.getTileEntity(x, y, z);
-    	    	int numUpgrades = tileMachine.getUpgrades();
-    	    	while (numUpgrades>0) {
-    	    		ItemStack upgrades = ToolHelper.getUpgradeType(tileMachine.getUpgradeLevel());
-    	    		if (numUpgrades<=64) {
-    	    			upgrades.stackSize = numUpgrades;
-    	    			numUpgrades = 0;
-    	    		} else {
-    	    			upgrades.stackSize = 64;
-    	    			numUpgrades -= 64;
-    	    		}
-    	    		items.add(upgrades);
-    	    	}
-    	    	tileMachine.setUpgrades(numUpgrades);
-    	    }
+
+			if (tileEntity instanceof UpgradeableTileEntity) {
+				UpgradeableTileEntity tileMachine = (UpgradeableTileEntity)tileEntity;
+				for (UpgradeType upgradeType : tileMachine.getInstalledUpgradeTypes()) {
+					int amount = tileMachine.getUpgradeAmount(upgradeType);
+					while (amount > 0) {
+						ItemStack upgradeItemStack = new ItemStack(UpgradeRegistry.getUpgradeItem(upgradeType));
+						int stackSize = amount > 64 ? 64 : amount;
+						upgradeItemStack.stackSize = stackSize;
+						amount -= stackSize;
+						items.add(upgradeItemStack);
+					}
+				}
+			}
 		}
 		
 		return items;

--- a/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
+++ b/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
@@ -142,10 +142,6 @@ public class BaseBlock extends BlockContainer implements IDismantleable {
 		entItem.motionY = (double)((float)world.rand.nextGaussian() * f3 + 0.2F);
 		entItem.motionZ = (double)((float)world.rand.nextGaussian() * f3);
 		
-		if (items.hasTagCompound()) {
-			entItem.getEntityItem().setTagCompound((NBTTagCompound)items.getTagCompound().copy());
-        }
-		
 		world.spawnEntityInWorld(entItem);
 	}
 	
@@ -226,74 +222,26 @@ public class BaseBlock extends BlockContainer implements IDismantleable {
 	@Override
 	public ArrayList<ItemStack> dismantleBlock(EntityPlayer player,
 			World world, int x, int y, int z, boolean returnDrops) {
-		ArrayList<ItemStack> items = new ArrayList<ItemStack>();
-		
-		//ProgressiveAutomation.logger.info("Dismatle Called");
 		
 		Block targetBlock = world.getBlock(x, y, z);
-		int meta = world.getBlockMetadata(x, y, z);
-		
-		//this should be able to save the state of the machine and put it back when placed again
-		//but it doesn't seem to persist after restarting the world. I don't know why?!?
-		/*BaseTileEntity tileEntity = (BaseTileEntity)world.getTileEntity(x, y, z);
-		NBTTagCompound blockNBT = new NBTTagCompound();
-		tileEntity.writeToNBT(blockNBT);*/
-		
 		ItemStack block = new ItemStack(targetBlock);
-		if (block.stackTagCompound == null) {
-			NBTTagCompound blockNBT = new NBTTagCompound();
-			
-			//get the current upgrades
-			if (world.getTileEntity(x, y, z) instanceof UpgradeableTileEntity) {
-				UpgradeableTileEntity upgradable = ((UpgradeableTileEntity) world.getTileEntity(x, y, z));
-				//upgrades
-				blockNBT.setInteger("upgrades", upgradable.getUpgrades());
-				upgradable.setUpgrades(0);
-				//cobbleUpgrade
-				blockNBT.setBoolean("hasCobbleUpgrade", upgradable.hasCobbleUpgrade);
-				upgradable.hasCobbleUpgrade = false;
-				//witherUpgrade
-				blockNBT.setBoolean("hasWitherUpgrade", upgradable.hasWitherUpgrade);
-				upgradable.hasWitherUpgrade = false;
-				//fillerUpgrade
-				blockNBT.setBoolean("hasFillerUpgrade", upgradable.hasFillerUpgrade);
-				upgradable.hasFillerUpgrade = false;
-			}
-			if (world.getTileEntity(x, y, z) instanceof BaseTileEntity) {
-				BaseTileEntity tileEntity = ((BaseTileEntity) world.getTileEntity(x, y, z));
-				//grab the inventory and save it to NBT
-				NBTTagList contents = new NBTTagList();
-				for (int i = 0; i < tileEntity.getSizeInventory(); i++) {
-					ItemStack stack = tileEntity.getStackInSlot(i);
-					if (stack!=null) {
-						NBTTagCompound tag = new NBTTagCompound();
-						tag.setByte("Slot", (byte)i);
-						stack.writeToNBT(tag);
-						contents.appendTag(tag);
-						tileEntity.setInventorySlotContents(i, null);
-					}
-				}
-				blockNBT.setTag("Contents", contents);
-			}
-			block.setTagCompound(blockNBT);
+
+		// Get the NBT tag contents
+		if (world.getTileEntity(x, y, z) instanceof BaseTileEntity) {
+			BaseTileEntity tileEntity = ((BaseTileEntity) world.getTileEntity(x, y, z));
+			tileEntity.writeToItemStack(block);
 		}
-		
-		items.add(block);
+
 		
 		if (!returnDrops) {
-			for (ItemStack item: items) {
-	        	dumpItems(world, x, y, z, item);
-	        }
+	        dumpItems(world, x, y, z, block);
+			// Remove the tile entity first, so inventory/upgrades doesn't get dumped
+			world.removeTileEntity(x, y, z);
+			world.setBlockToAir(x, y, z);
 		}
-		
-		
-		//delete the inventory so it doesn't drop
-		/*for (int i = 0; i < tileEntity.getSizeInventory(); i++) {
-			tileEntity.setInventorySlotContents(i, null);
-		}
-		getInsides(world, x, y, z);*/
-		
-		world.setBlockToAir(x, y, z);
+
+		ArrayList<ItemStack> items = new ArrayList<ItemStack>();
+		items.add(block);
 		return items;
 	}
 

--- a/src/main/java/com/vanhal/progressiveautomation/entities/BaseTileEntity.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/BaseTileEntity.java
@@ -130,7 +130,7 @@ public class BaseTileEntity extends TileEntity implements ISidedInventory, IEner
 	 * They are automagically synced when a GUI is opened using S30PacketWindowItems 
 	 * @param nbt
 	 */
-	protected void writeCommonNBT(NBTTagCompound nbt) {
+	public void writeCommonNBT(NBTTagCompound nbt) {
 		nbt.setInteger("Progress", progress);
 		nbt.setInteger("BurnLevel", burnLevel);
 	}
@@ -143,7 +143,7 @@ public class BaseTileEntity extends TileEntity implements ISidedInventory, IEner
 	 * See writeSyncableNBT for more info.
 	 * @param nbt
 	 */
-	protected void writeNonSyncableNBT(NBTTagCompound nbt) {
+	public void writeNonSyncableNBT(NBTTagCompound nbt) {
 		
 		NBTTagList contents = new NBTTagList();
 		for (int i = 0; i < slots.length; i++) {
@@ -266,6 +266,15 @@ public class BaseTileEntity extends TileEntity implements ISidedInventory, IEner
 	protected void addPartialUpdate(String fieldName, Boolean value) {
 		partialUpdateTag.setBoolean(fieldName, value);
 		dirty = true;
+	}
+
+	protected void addPartialUpdate(String fieldName, NBTTagCompound value) {
+		partialUpdateTag.setTag(fieldName, value);
+		dirty = true;
+	}
+
+	protected NBTTagCompound getCompoundTagFromPartialUpdate(String fieldName) {
+		return partialUpdateTag.getCompoundTag(fieldName);
 	}
 	
 	/**

--- a/src/main/java/com/vanhal/progressiveautomation/entities/BaseTileEntity.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/BaseTileEntity.java
@@ -94,6 +94,25 @@ public class BaseTileEntity extends TileEntity implements ISidedInventory, IEner
 		readCommonNBT(nbt);
 		readNonSyncableNBT(nbt);
 	}
+
+	public void readFromItemStack(ItemStack itemStack) {
+		if (itemStack == null || itemStack.stackTagCompound == null) {
+			return;
+		}
+		readCommonNBT(itemStack.stackTagCompound);
+		readNonSyncableNBT(itemStack.stackTagCompound);
+	}
+
+	public void writeToItemStack(ItemStack itemStack) {
+		if (itemStack == null ) {
+			return;
+		}
+		if (itemStack.stackTagCompound == null) {
+			itemStack.stackTagCompound = new NBTTagCompound();
+		}
+		writeCommonNBT(itemStack.stackTagCompound);
+		writeNonSyncableNBT(itemStack.stackTagCompound);
+	}
 	
 	/**
 	 * This overridable method is intended for writing to NBT all data that is used only at runtime

--- a/src/main/java/com/vanhal/progressiveautomation/entities/IUpgradeable.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/IUpgradeable.java
@@ -1,13 +1,18 @@
 package com.vanhal.progressiveautomation.entities;
 
-import com.vanhal.progressiveautomation.PAConfig;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
+
+import java.util.Set;
 
 public interface IUpgradeable {
-	
+
+	@Deprecated
 	public int getUpgrades();
 
+	@Deprecated
 	public void setUpgrades(int value);
 
+	@Deprecated
 	public void addUpgrades(int addValue);
 	
 	public int getRange();
@@ -15,4 +20,18 @@ public interface IUpgradeable {
 	public int getUpgradeLevel();
 	
 	public void setUpgradeLevel(int level);
+
+	public boolean isAllowedUpgrade(UpgradeType type);
+
+	public boolean hasUpgrade(UpgradeType type);
+
+	public Integer getUpgradeAmount(UpgradeType type);
+
+	public void setUpgradeAmount(UpgradeType type, Integer amount);
+
+	public void addUpgrade(UpgradeType type, Integer amount);
+
+	public void removeUpgradeCompletely(UpgradeType type);
+
+	public Set<UpgradeType> getInstalledUpgradeTypes();
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/UpgradeableTileEntity.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/UpgradeableTileEntity.java
@@ -1,63 +1,136 @@
 package com.vanhal.progressiveautomation.entities;
 
-import net.minecraft.init.Blocks;
+import com.google.common.base.Enums;
+import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
 
 import com.vanhal.progressiveautomation.PAConfig;
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
-import com.vanhal.progressiveautomation.items.upgrades.ItemCobbleGenUpgrade;
-import com.vanhal.progressiveautomation.items.upgrades.ItemFillerUpgrade;
-import com.vanhal.progressiveautomation.items.upgrades.ItemWitherUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
-import com.vanhal.progressiveautomation.util.Point2I;
+
+import java.util.*;
 
 public class UpgradeableTileEntity extends BaseTileEntity implements IUpgradeable {
 	protected int toolLevel = ToolHelper.LEVEL_WOOD;
-	protected int numberUpgrades = 0;
-	
-	//other types of upgrades
-	public boolean hasWitherUpgrade = false;
-	public boolean hasCobbleUpgrade = false;
-	public boolean hasFillerUpgrade = false;
+
+	private Map<UpgradeType, Integer> installedUpgrades;
+	private Set<UpgradeType> allowedUpgrades;
 
 	public UpgradeableTileEntity(int numSlots) {
 		super(numSlots);
+		installedUpgrades = new EnumMap<UpgradeType, Integer>(UpgradeType.class);
+		allowedUpgrades = Collections.emptySet();
 	}
 	
 	public void writeCommonNBT(NBTTagCompound nbt) {
 		super.writeCommonNBT(nbt);
-		nbt.setInteger("NumUpgrades", numberUpgrades);
-		nbt.setBoolean("hasWitherUpgrade", hasWitherUpgrade);
-		nbt.setBoolean("hasCobbleUpgrade", hasCobbleUpgrade);
-		nbt.setBoolean("hasFillerUpgrade", hasFillerUpgrade);
+
+		// Save upgrades
+		NBTTagCompound tag = new NBTTagCompound();
+		for (Map.Entry<UpgradeType, Integer> mapEntry : installedUpgrades.entrySet()) {
+			tag.setInteger(mapEntry.getKey().name(), mapEntry.getValue());
+		}
+		nbt.setTag("installedUpgrades", tag);
 	}
 
 	public void readCommonNBT(NBTTagCompound nbt) {
 		super.readCommonNBT(nbt);
-		if (nbt.hasKey("NumUpgrades")) numberUpgrades = nbt.getInteger("NumUpgrades");
-		if (nbt.hasKey("hasWitherUpgrade")) hasWitherUpgrade = nbt.getBoolean("hasWitherUpgrade");
-		if (nbt.hasKey("hasCobbleUpgrade")) hasCobbleUpgrade = nbt.getBoolean("hasCobbleUpgrade");
-		if (nbt.hasKey("hasFillerUpgrade")) hasFillerUpgrade = nbt.getBoolean("hasFillerUpgrade");
+		readLegacyNBT(nbt);
+
+		// Load upgrades
+		NBTTagCompound tag = nbt.getCompoundTag("installedUpgrades");
+		if (tag != null) {
+			// func_150296_c() returns a set of all tag names inside the NBTTagCompound
+			for (Object key : tag.func_150296_c()) {
+				String upgradeName = (String) key;
+				installedUpgrades.put(UpgradeType.valueOf(upgradeName), tag.getInteger(upgradeName));
+			}
+		}
+	}
+
+	/**
+	 * Method kept for compatibility reasons. Needs to be removed at a later date.
+	 * Minecraft must load chunks with placed machines (and afterwards, save the world)
+	 * for legacy NBT to convert into the new map.
+	 * @param nbt NBTTagCompound
+	 */
+	@Deprecated
+	private void readLegacyNBT(NBTTagCompound nbt) {
+		if (nbt.hasKey("NumUpgrades") && nbt.getInteger("NumUpgrades") > 0)
+			installedUpgrades.put(UpgradeType.getRangeUpgrade(toolLevel), nbt.getInteger("NumUpgrades"));
+		if (nbt.hasKey("hasWitherUpgrade") && nbt.getInteger("hasWitherUpgrade") > 0)
+			installedUpgrades.put(UpgradeType.WITHER, nbt.getInteger("hasWitherUpgrade"));
+		if (nbt.hasKey("hasCobbleUpgrade") && nbt.getInteger("hasCobbleUpgrade") > 0)
+			installedUpgrades.put(UpgradeType.COBBLE_GEN, nbt.getInteger("hasCobbleUpgrade"));
+		if (nbt.hasKey("hasFillerUpgrade") && nbt.getInteger("hasFillerUpgrade") > 0)
+			installedUpgrades.put(UpgradeType.FILLER, nbt.getInteger("hasFillerUpgrade"));
 	}
 	
 	/* IUpgradeable methods */
+	@Override
+	public boolean hasUpgrade(UpgradeType type) {
+		return installedUpgrades.get(type) != null;
+	}
+
+	@Override
+	public Integer getUpgradeAmount(UpgradeType type) {
+		Integer upgradeAmount = installedUpgrades.get(type);
+		return upgradeAmount != null ? upgradeAmount : 0;
+	}
+
+	@Override
+	public void addUpgrade(UpgradeType type, Integer amount) {
+		setUpgradeAmount(type, getUpgradeAmount(type) + amount);
+	}
+
+	@Override
+	public void setUpgradeAmount(UpgradeType type, Integer amount) {
+		installedUpgrades.put(type, amount);
+
+		NBTTagCompound tag = getCompoundTagFromPartialUpdate("installedUpgrades");
+		if (tag == null) {
+			tag = new NBTTagCompound();
+		}
+		tag.setInteger(type.name(), amount);
+		addPartialUpdate("installedUpgrades", tag);
+	}
+
+	@Override
+	public void removeUpgradeCompletely(UpgradeType type) {
+		installedUpgrades.remove(type);
+
+		NBTTagCompound tag = getCompoundTagFromPartialUpdate("installedUpgrades");
+		if (tag == null) {
+			tag = new NBTTagCompound();
+		}
+		tag.setInteger(type.name(), 0);
+		addPartialUpdate("upgrades", tag);
+	}
+
+	@Override
+	public Set<UpgradeType> getInstalledUpgradeTypes() {
+		return installedUpgrades.keySet();
+	}
+
 	public int getUpgrades() {
-		return numberUpgrades;
+		return getUpgradeAmount(UpgradeType.getRangeUpgrade(toolLevel));
 	}
 
 	public void setUpgrades(int value) {
-		numberUpgrades = value;
+		UpgradeType type = UpgradeType.getRangeUpgrade(toolLevel);
+		setUpgradeAmount(type, value);
 	}
 
 	public void addUpgrades(int addValue) {
-		numberUpgrades += addValue;
+		addUpgrade(UpgradeType.getRangeUpgrade(toolLevel), addValue);
 	}
 
 	public int getRange() {
 		int range = (getUpgrades() * PAConfig.upgradeRange) + 1;
-		if (hasWitherUpgrade) range = range * PAConfig.witherMultiplier;
+		if (hasUpgrade(UpgradeType.WITHER)) range = range * PAConfig.witherMultiplier;
 		return range;
 	}
 
@@ -68,10 +141,13 @@ public class UpgradeableTileEntity extends BaseTileEntity implements IUpgradeabl
 	public void setUpgradeLevel(int level) {
 		toolLevel = level;
 	}
-	
-	//check for changes to upgrades
-	protected int lastUpgrades = 0;
-	
+
+	@Override
+	public boolean isAllowedUpgrade(UpgradeType type) {
+		return allowedUpgrades.contains(type);
+	}
+
+
 	public void updateEntity() {
 		super.updateEntity();
 		if (!worldObj.isRemote) {
@@ -79,23 +155,15 @@ public class UpgradeableTileEntity extends BaseTileEntity implements IUpgradeabl
 			
 			// Something inside the upgrade slot
 			if (upgrade != null && upgrade.stackSize > 0) {
-				
-				if (upgrade.isItemEqual(ToolHelper.getUpgradeType(getUpgradeLevel()))) {
-					addUpgrades(upgrade.stackSize);
-					upgrade.stackSize = 0;
-					addPartialUpdate("NumUpgrades", getUpgrades());
-				} else if (upgrade.getItem() instanceof ItemCobbleGenUpgrade && !hasCobbleUpgrade) {
-					hasCobbleUpgrade = true;
-					upgrade.stackSize--;
-					addPartialUpdate("hasCobbleUpgrade", hasCobbleUpgrade);
-				} else if (upgrade.getItem() instanceof ItemFillerUpgrade && !hasFillerUpgrade) {
-					hasFillerUpgrade = true;
-					upgrade.stackSize--;
-					addPartialUpdate("hasFillerUpgrade", hasFillerUpgrade);
-				} else if (upgrade.getItem() instanceof ItemWitherUpgrade && !hasWitherUpgrade) {
-					hasWitherUpgrade = true;
-					upgrade.stackSize--;
-					addPartialUpdate("hasWitherUpgrade", hasWitherUpgrade);
+				ItemUpgrade upgradeItem = (ItemUpgrade) upgrade.getItem();
+				UpgradeType type = upgradeItem.getType();
+				int installedAmount = getUpgradeAmount(type);
+
+				if (allowedUpgrades.contains(upgradeItem.getType()) && installedAmount < upgradeItem.allowedAmount()) {
+					int newTotal = installedAmount + upgrade.stackSize;
+					upgrade.stackSize = newTotal <= upgradeItem.allowedAmount() ? 0 : newTotal - upgradeItem.allowedAmount();
+					newTotal = newTotal - upgrade.stackSize;
+					setUpgradeAmount(type, newTotal);
 				}
 				
 				// We've eaten all items in this stack, it should be disposed of
@@ -108,19 +176,6 @@ public class UpgradeableTileEntity extends BaseTileEntity implements IUpgradeabl
 				ProgressiveAutomation.logger.warn("Inserted ItemStack with stacksize <= 0. Deleting");
 				slots[SLOT_UPGRADE] = null;
 			}
-		}
-	}
-	
-	public void checkForChanges() {
-//		this.upgradeChanges();
-	}
-	
-	protected int getCurrentUpgrades() {
-		if (SLOT_UPGRADE==-1) return 0;
-		if (this.getStackInSlot(SLOT_UPGRADE)==null) {
-			return 0;
-		} else {
-			return this.getStackInSlot(SLOT_UPGRADE).stackSize;
 		}
 	}
 	
@@ -152,5 +207,17 @@ public class UpgradeableTileEntity extends BaseTileEntity implements IUpgradeabl
     		return true;
      	}
 		return false;
+	}
+
+	protected Set<UpgradeType> getAllowedUpgrades() {
+		return allowedUpgrades;
+	}
+
+	protected void setAllowedUpgrades(Set<UpgradeType> allowedUpgrades) {
+		this.allowedUpgrades = allowedUpgrades;
+	}
+
+	protected void setAllowedUpgrades(UpgradeType first, UpgradeType... rest) {
+		this.allowedUpgrades = EnumSet.of(first, rest);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/UpgradeableTileEntity.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/UpgradeableTileEntity.java
@@ -7,9 +7,9 @@ import net.minecraft.tileentity.TileEntityFurnace;
 
 import com.vanhal.progressiveautomation.PAConfig;
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
-import com.vanhal.progressiveautomation.items.ItemCobbleGenUpgrade;
-import com.vanhal.progressiveautomation.items.ItemFillerUpgrade;
-import com.vanhal.progressiveautomation.items.ItemWitherUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemCobbleGenUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemFillerUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemWitherUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 import com.vanhal.progressiveautomation.util.Point2I;
 

--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
@@ -2,6 +2,7 @@ package com.vanhal.progressiveautomation.entities.chopper;
 
 import java.util.ArrayList;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -47,6 +48,7 @@ public class TileChopper extends UpgradeableTileEntity {
 	public TileChopper() {
 		super(12);
 		setUpgradeLevel(ToolHelper.LEVEL_WOOD);
+		setAllowedUpgrades(UpgradeType.WOODEN, UpgradeType.WITHER);
 		forceRecalculate = true;
 		
 		//slots

--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperDiamond.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperDiamond.java
@@ -1,11 +1,13 @@
 package com.vanhal.progressiveautomation.entities.chopper;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileChopperDiamond extends TileChopper {
 
 	public TileChopperDiamond() {
 		super();
+		setAllowedUpgrades(UpgradeType.DIAMOND, UpgradeType.WITHER);
 		setUpgradeLevel(10);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperIron.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperIron.java
@@ -1,11 +1,13 @@
 package com.vanhal.progressiveautomation.entities.chopper;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileChopperIron extends TileChopper {
 
 	public TileChopperIron() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_IRON);
+		setAllowedUpgrades(UpgradeType.IRON, UpgradeType.WITHER);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperStone.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopperStone.java
@@ -1,11 +1,13 @@
 package com.vanhal.progressiveautomation.entities.chopper;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileChopperStone extends TileChopper {
 
 	public TileChopperStone() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_STONE);
+		setAllowedUpgrades(UpgradeType.STONE, UpgradeType.WITHER);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMiner.java
@@ -1,7 +1,9 @@
 package com.vanhal.progressiveautomation.entities.miner;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import com.vanhal.progressiveautomation.util.Point2I;
 import com.vanhal.progressiveautomation.PAConfig;
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
@@ -42,6 +44,7 @@ public class TileMiner extends UpgradeableTileEntity {
 	public TileMiner() {
 		super(13);
 		setUpgradeLevel(ToolHelper.LEVEL_WOOD);
+		setAllowedUpgrades(UpgradeType.WOODEN, UpgradeType.WITHER, UpgradeType.COBBLE_GEN, UpgradeType.FILLER);
 		
 		//set the slots
 		SLOT_PICKAXE = 2;
@@ -134,7 +137,7 @@ public class TileMiner extends UpgradeableTileEntity {
 			}
 			
 			//see if the filler upgrade is active, if it is then the block will need to be filled.
-			if (this.hasFillerUpgrade) {
+			if (hasUpgrade(UpgradeType.FILLER)) {
 				if ( (tryBlock.isAir(worldObj, x, y, z)) || (tryBlock.getMaterial().isLiquid()) ) {
 					return 4;
 				}
@@ -316,7 +319,7 @@ public class TileMiner extends UpgradeableTileEntity {
 	
 	//if we have a cobblegen upgrade then this function will deal with adding cobble that is generated
 	public void useCobbleGen() {
-		if (this.hasCobbleUpgrade) {
+		if (hasUpgrade(UpgradeType.COBBLE_GEN)) {
 			if ( (slots[1] == null) || (slots[1].stackSize==0) ) {
 				if (slots[SLOT_PICKAXE]!=null) {
 					if (ToolHelper.damageTool(slots[SLOT_PICKAXE], worldObj, this.xCoord, this.yCoord, this.zCoord)) {

--- a/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerDiamond.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerDiamond.java
@@ -1,11 +1,13 @@
 package com.vanhal.progressiveautomation.entities.miner;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileMinerDiamond extends TileMiner {
 
 	public TileMinerDiamond() {
 		super();
 		setUpgradeLevel(10);
+		setAllowedUpgrades(UpgradeType.DIAMOND, UpgradeType.WITHER, UpgradeType.COBBLE_GEN, UpgradeType.FILLER);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerIron.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerIron.java
@@ -1,10 +1,12 @@
 package com.vanhal.progressiveautomation.entities.miner;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileMinerIron extends TileMiner {
 	public TileMinerIron() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_IRON);
+		setAllowedUpgrades(UpgradeType.IRON, UpgradeType.WITHER, UpgradeType.COBBLE_GEN, UpgradeType.FILLER);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerStone.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMinerStone.java
@@ -1,11 +1,13 @@
 package com.vanhal.progressiveautomation.entities.miner;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TileMinerStone extends TileMiner {
 
 	public TileMinerStone() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_STONE);
+		setAllowedUpgrades(UpgradeType.STONE, UpgradeType.WITHER, UpgradeType.COBBLE_GEN, UpgradeType.FILLER);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanter.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanter.java
@@ -2,6 +2,7 @@ package com.vanhal.progressiveautomation.entities.planter;
 
 import java.util.ArrayList;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockNetherWart;
 import net.minecraft.block.IGrowable;
@@ -36,6 +37,7 @@ public class TilePlanter extends UpgradeableTileEntity {
 	public TilePlanter() {
 		super(12);
 		setUpgradeLevel(ToolHelper.LEVEL_WOOD);
+		setAllowedUpgrades(UpgradeType.WOODEN, UpgradeType.WITHER);
 		setHarvestTime(80);
 		
 		// #36 Planter can't eject items to bottom
@@ -54,7 +56,6 @@ public class TilePlanter extends UpgradeableTileEntity {
 		super.updateEntity();
 		if (!worldObj.isRemote) {
 			checkInventory();
-			checkForChanges();
 
 			if (isBurning()) {
 				if (searchBlock > -1) {

--- a/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterDiamond.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterDiamond.java
@@ -1,12 +1,14 @@
 package com.vanhal.progressiveautomation.entities.planter;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TilePlanterDiamond extends TilePlanter {
 
 	public TilePlanterDiamond() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_DIAMOND);
+		setAllowedUpgrades(UpgradeType.DIAMOND, UpgradeType.WITHER);
 		setHarvestTime(10);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterIron.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterIron.java
@@ -1,12 +1,14 @@
 package com.vanhal.progressiveautomation.entities.planter;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TilePlanterIron extends TilePlanter {
 
 	public TilePlanterIron() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_IRON);
+		setAllowedUpgrades(UpgradeType.IRON, UpgradeType.WITHER);
 		setHarvestTime(20);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterStone.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanterStone.java
@@ -1,12 +1,14 @@
 package com.vanhal.progressiveautomation.entities.planter;
 
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 public class TilePlanterStone extends TilePlanter {
 
 	public TilePlanterStone() {
 		super();
 		setUpgradeLevel(ToolHelper.LEVEL_STONE);
+		setAllowedUpgrades(UpgradeType.STONE, UpgradeType.WITHER);
 		setHarvestTime(40);
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIChopper.java
@@ -1,5 +1,6 @@
 package com.vanhal.progressiveautomation.gui.client;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.tileentity.TileEntity;
@@ -28,7 +29,7 @@ public class GUIChopper extends BaseGUI {
 	
 	protected void drawText() {
 		drawString(StringHelper.localize("gui.chopper"), 5, GRAY);
-		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(chopper.getRange()), infoScreenX, infoScreenW, infroScreenY3, (chopper.hasWitherUpgrade)?GREEN:WHITE);
+		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(chopper.getRange()), infoScreenX, infoScreenW, infroScreenY3, (chopper.hasUpgrade(UpgradeType.WITHER))?GREEN:WHITE);
 		
 		boolean readyToChop = false;
 		if ( (!chopper.hasFuel()) && (!chopper.isBurning()) ) {

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIMiner.java
@@ -5,6 +5,7 @@ import com.vanhal.progressiveautomation.ProgressiveAutomation;
 import com.vanhal.progressiveautomation.entities.miner.TileMiner;
 import com.vanhal.progressiveautomation.gui.container.ContainerMiner;
 import com.vanhal.progressiveautomation.ref.Ref;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import com.vanhal.progressiveautomation.util.StringHelper;
 
 import net.minecraft.entity.player.InventoryPlayer;
@@ -29,7 +30,7 @@ public class GUIMiner extends BaseGUI {
 	
 	protected void drawText() {
 		drawString(StringHelper.localize("gui.miner"), 5, GRAY);
-		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(miner.getRange()), infoScreenX, infoScreenW, infroScreenY3, (miner.hasWitherUpgrade)?GREEN:WHITE);
+		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(miner.getRange()), infoScreenX, infoScreenW, infroScreenY3, (miner.hasUpgrade(UpgradeType.WITHER))?GREEN:WHITE);
 		boolean readyToMine = true;
 		if ( (!miner.hasFuel()) && (!miner.isBurning()) ) {
 			String fuelString = "gui.need.fuel";
@@ -60,7 +61,7 @@ public class GUIMiner extends BaseGUI {
 	
 	protected void drawElements() {
 		drawFlame(miner.getPercentDone(), 10, 34);
-		if (miner.hasCobbleUpgrade) {
+		if (miner.hasUpgrade(UpgradeType.COBBLE_GEN)) {
 			drawTexturedModalRect(guiLeft - 25, guiTop + 10, 231, 0, 25, 64);
 			
 		}

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIPlanter.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIPlanter.java
@@ -1,5 +1,6 @@
 package com.vanhal.progressiveautomation.gui.client;
 
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -27,7 +28,7 @@ public class GUIPlanter extends BaseGUI {
 	
 	protected void drawText() {
 		drawString(StringHelper.localize("gui.planter"), 5, GRAY);
-		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(planter.getRange()), infoScreenX, infoScreenW, infroScreenY3, (planter.hasWitherUpgrade)?GREEN:WHITE);
+		drawString(StringHelper.localize("gui.range")+": "+StringHelper.getScaledNumber(planter.getRange()), infoScreenX, infoScreenW, infroScreenY3, (planter.hasUpgrade(UpgradeType.WITHER))?GREEN:WHITE);
 		
 		boolean readyToPlant = false;
 		if ( (!planter.hasFuel()) && (!planter.isBurning()) ) {

--- a/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerChopper.java
@@ -1,28 +1,15 @@
 package com.vanhal.progressiveautomation.gui.container;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.ICrafting;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityFurnace;
-import net.minecraftforge.oredict.OreDictionary;
 
 import com.vanhal.progressiveautomation.entities.BaseTileEntity;
 import com.vanhal.progressiveautomation.entities.chopper.TileChopper;
-import com.vanhal.progressiveautomation.gui.slots.SlotDictionary;
-import com.vanhal.progressiveautomation.gui.slots.SlotItem;
 import com.vanhal.progressiveautomation.gui.slots.SlotSaplings;
 import com.vanhal.progressiveautomation.gui.slots.SlotTool;
 import com.vanhal.progressiveautomation.gui.slots.SlotUpgrades;
-import com.vanhal.progressiveautomation.items.ItemRFEngine;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ContainerChopper extends BaseContainer {
 	protected ItemStack updateType;
@@ -36,7 +23,7 @@ public class ContainerChopper extends BaseContainer {
 		//add slots
 		this.addSlotToContainer(new SlotSaplings(chopper, chopper.SLOT_SAPLINGS, 11, 16)); //saplings
 		this.addSlotToContainer(new SlotTool(ToolHelper.TYPE_AXE,  chopper.getUpgradeLevel(), chopper, chopper.SLOT_AXE, 49, 52)); //axe
-		this.addSlotToContainer(new SlotUpgrades(chopper.getUpgradeLevel(), chopper, chopper.SLOT_UPGRADE, 76, 52)); //upgrades
+		this.addSlotToContainer(new SlotUpgrades(chopper, chopper.SLOT_UPGRADE, 76, 52)); //upgrades
 
 		//output slots
 		addInventory(chopper, chopper.SLOT_INVENTORY_START, 112, 16, 3, 3);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerMiner.java
@@ -1,30 +1,16 @@
 package com.vanhal.progressiveautomation.gui.container;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.ICrafting;
-import net.minecraft.inventory.Slot;
-import net.minecraft.inventory.SlotFurnace;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityFurnace;
 
-import com.vanhal.progressiveautomation.ProgressiveAutomation;
 import com.vanhal.progressiveautomation.entities.BaseTileEntity;
 import com.vanhal.progressiveautomation.entities.miner.TileMiner;
-import com.vanhal.progressiveautomation.gui.slots.SlotBurn;
 import com.vanhal.progressiveautomation.gui.slots.SlotItem;
 import com.vanhal.progressiveautomation.gui.slots.SlotTool;
 import com.vanhal.progressiveautomation.gui.slots.SlotUpgrades;
-import com.vanhal.progressiveautomation.items.ItemRFEngine;
-import com.vanhal.progressiveautomation.items.PAItems;
-import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class ContainerMiner extends BaseContainer {
 	protected ItemStack updateType;
@@ -41,7 +27,7 @@ public class ContainerMiner extends BaseContainer {
 		this.addSlotToContainer(new SlotItem(new ItemStack(Blocks.cobblestone), miner, 1, 11, 16)); //cobble
 		this.addSlotToContainer(new SlotTool(ToolHelper.TYPE_PICKAXE,  miner.getUpgradeLevel(), miner, miner.SLOT_PICKAXE, 37, 52)); //pickaxe
 		this.addSlotToContainer(new SlotTool(ToolHelper.TYPE_SHOVEL, miner.getUpgradeLevel(), miner, miner.SLOT_SHOVEL, 63, 52)); //shovel
-		this.addSlotToContainer(new SlotUpgrades(miner.getUpgradeLevel(), miner, miner.SLOT_UPGRADE, 89, 52)); //upgrades
+		this.addSlotToContainer(new SlotUpgrades(miner, miner.SLOT_UPGRADE, 89, 52)); //upgrades
 
 		//output slots
 		addInventory(miner, miner.SLOT_INVENTORY_START, 112, 16, 3, 3);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerMiner.java
@@ -19,8 +19,8 @@ import com.vanhal.progressiveautomation.gui.slots.SlotItem;
 import com.vanhal.progressiveautomation.gui.slots.SlotTool;
 import com.vanhal.progressiveautomation.gui.slots.SlotUpgrades;
 import com.vanhal.progressiveautomation.items.ItemRFEngine;
-import com.vanhal.progressiveautomation.items.ItemUpgrade;
 import com.vanhal.progressiveautomation.items.PAItems;
+import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 
 import cpw.mods.fml.relauncher.Side;

--- a/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerPlanter.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/container/ContainerPlanter.java
@@ -2,25 +2,14 @@ package com.vanhal.progressiveautomation.gui.container;
 
 import com.vanhal.progressiveautomation.entities.BaseTileEntity;
 import com.vanhal.progressiveautomation.entities.planter.TilePlanter;
-import com.vanhal.progressiveautomation.gui.slots.SlotDictionary;
-import com.vanhal.progressiveautomation.gui.slots.SlotItem;
 import com.vanhal.progressiveautomation.gui.slots.SlotPlantable;
 import com.vanhal.progressiveautomation.gui.slots.SlotTool;
 import com.vanhal.progressiveautomation.gui.slots.SlotUpgrades;
-import com.vanhal.progressiveautomation.items.ItemRFEngine;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.init.Blocks;
-import net.minecraft.inventory.ICrafting;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityFurnace;
-import net.minecraftforge.oredict.OreDictionary;
 
 public class ContainerPlanter extends BaseContainer {
 	
@@ -36,7 +25,7 @@ public class ContainerPlanter extends BaseContainer {
 		//add slots
 		this.addSlotToContainer(new SlotPlantable(planter, planter.SLOT_SEEDS, 11, 16)); //seeds
 		this.addSlotToContainer(new SlotTool(ToolHelper.TYPE_HOE,  planter.getUpgradeLevel(), planter, planter.SLOT_HOE, 49, 52)); //hoe
-		this.addSlotToContainer(new SlotUpgrades(planter.getUpgradeLevel(), planter, planter.SLOT_UPGRADE, 76, 52)); //upgrades
+		this.addSlotToContainer(new SlotUpgrades(planter, planter.SLOT_UPGRADE, 76, 52)); //upgrades
 
 		//output slots
 		addInventory(planter, planter.SLOT_INVENTORY_START, 112, 16, 3, 3);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/slots/SlotUpgrades.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/slots/SlotUpgrades.java
@@ -1,6 +1,6 @@
 package com.vanhal.progressiveautomation.gui.slots;
 
-import com.vanhal.progressiveautomation.items.ItemUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 
 import net.minecraft.inventory.IInventory;

--- a/src/main/java/com/vanhal/progressiveautomation/gui/slots/SlotUpgrades.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/slots/SlotUpgrades.java
@@ -1,5 +1,8 @@
 package com.vanhal.progressiveautomation.gui.slots;
 
+import com.vanhal.progressiveautomation.entities.BaseTileEntity;
+import com.vanhal.progressiveautomation.entities.IUpgradeable;
+import com.vanhal.progressiveautomation.entities.UpgradeableTileEntity;
 import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 
@@ -8,24 +11,20 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
 public class SlotUpgrades extends Slot {
-	protected int level;
-	protected ItemStack updateType;
 	
-	public SlotUpgrades(int UpgradeLevel, IInventory par1iInventory, int par2, int par3, int par4) {
+	public SlotUpgrades(UpgradeableTileEntity par1iInventory, int par2, int par3, int par4) {
 		super(par1iInventory, par2, par3, par4);
-		level = UpgradeLevel;
-		updateType = ToolHelper.getUpgradeType(level);
 	}
 
 	public boolean isItemValid(ItemStack itemStack) {
-		if (itemStack.getItem() instanceof ItemUpgrade) {
-			ItemUpgrade currentUpgrade = (ItemUpgrade) itemStack.getItem();
-			if (currentUpgrade.getLevel()==-1) {
-				return true;
-			} else {
-				return updateType.isItemEqual(itemStack);
-			}
+		if (!(itemStack.getItem() instanceof ItemUpgrade)) {
+			return false;
 		}
-		return false;
+
+		IUpgradeable upgradeableMachine = (IUpgradeable) inventory;
+		ItemUpgrade currentUpgrade = (ItemUpgrade) itemStack.getItem();
+
+		return upgradeableMachine.isAllowedUpgrade(currentUpgrade.getType());
+
 	}
 }

--- a/src/main/java/com/vanhal/progressiveautomation/items/ItemBlockMachine.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/ItemBlockMachine.java
@@ -36,25 +36,9 @@ public class ItemBlockMachine extends ItemBlock {
 		boolean result = super.placeBlockAt(itemStack, player, world, x, y, z, side, hitX, hitY, hitZ, metadata);
 		if (result) {
 			if (!world.isRemote) {
-				if ( (itemStack != null) && (itemStack.stackTagCompound != null) ) {
-					if (world.getTileEntity(x, y, z) instanceof UpgradeableTileEntity) {
-						UpgradeableTileEntity upgradable = ((UpgradeableTileEntity) world.getTileEntity(x, y, z));
-						upgradable.setUpgrades(itemStack.stackTagCompound.getInteger("upgrades"));
-						upgradable.hasCobbleUpgrade = itemStack.stackTagCompound.getBoolean("hasCobbleUpgrade");
-						upgradable.hasWitherUpgrade = itemStack.stackTagCompound.getBoolean("hasWitherUpgrade");
-						upgradable.hasFillerUpgrade = itemStack.stackTagCompound.getBoolean("hasFillerUpgrade");
-					}
-					if (world.getTileEntity(x, y, z) instanceof BaseTileEntity) {
-						BaseTileEntity tileEntity = (BaseTileEntity)world.getTileEntity(x, y, z);
-						NBTTagList contents = itemStack.stackTagCompound.getTagList("Contents", 10);
-						for (int i = 0; i < contents.tagCount(); i++) {
-							NBTTagCompound tag = (NBTTagCompound) contents.getCompoundTagAt(i);
-							byte slot = tag.getByte("Slot");
-							if (slot < tileEntity.getSizeInventory()) {
-								tileEntity.setInventorySlotContents(slot, ItemStack.loadItemStackFromNBT(tag));
-							}
-						}
-					}
+				if (world.getTileEntity(x, y, z) instanceof BaseTileEntity) {
+					BaseTileEntity tileEntity = (BaseTileEntity) world.getTileEntity(x, y, z);
+					tileEntity.readFromItemStack(itemStack);
 				}
 			}
 		}

--- a/src/main/java/com/vanhal/progressiveautomation/items/PAItems.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/PAItems.java
@@ -72,7 +72,7 @@ public class PAItems {
 	}
 
 	public static void init() {
-		if (cobbleUpgrade!=null) cobbleUpgrade.preInit(null);
+		if (cobbleUpgrade!=null) cobbleUpgrade.preInit();
 	}
 
 	public static void postInit() {

--- a/src/main/java/com/vanhal/progressiveautomation/items/PAItems.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/PAItems.java
@@ -9,6 +9,13 @@ import com.vanhal.progressiveautomation.items.tools.ItemWitherIron;
 import com.vanhal.progressiveautomation.items.tools.ItemWitherStone;
 import com.vanhal.progressiveautomation.items.tools.ItemWitherWood;
 import com.vanhal.progressiveautomation.items.tools.WitherTools;
+import com.vanhal.progressiveautomation.items.upgrades.ItemCobbleGenUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemDiamondUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemFillerUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemIronUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemStoneUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemWitherUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemWoodUpgrade;
 
 public class PAItems {
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemCobbleGenUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemCobbleGenUpgrade.java
@@ -16,6 +16,7 @@ import com.vanhal.progressiveautomation.blocks.BlockMiner;
 import com.vanhal.progressiveautomation.blocks.PABlocks;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -23,7 +24,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemCobbleGenUpgrade extends ItemUpgrade {
 	public ItemCobbleGenUpgrade() {
-		super("CobbleUpgrade", -1);
+		super("CobbleUpgrade", UpgradeType.COBBLE_GEN);
 		this.setTextureName(Ref.MODID+":Cobble_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemCobbleGenUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemCobbleGenUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import java.util.List;
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemDiamondUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemDiamondUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemDiamondUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemDiamondUpgrade.java
@@ -9,12 +9,13 @@ import net.minecraftforge.oredict.ShapelessOreRecipe;
 import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 
-public class ItemDiamondUpgrade extends ItemUpgrade {
+public class ItemDiamondUpgrade extends ItemTieredUpgrade {
 	public ItemDiamondUpgrade() {
-		super("DiamondUpgrade", ToolHelper.LEVEL_DIAMOND);
+		super("DiamondUpgrade", UpgradeType.DIAMOND, ToolHelper.LEVEL_DIAMOND);
 		this.setTextureName(Ref.MODID+":Diamond_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemFillerUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemFillerUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import java.util.List;
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemFillerUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemFillerUpgrade.java
@@ -12,6 +12,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import com.vanhal.progressiveautomation.blocks.PABlocks;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -19,7 +20,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemFillerUpgrade extends ItemUpgrade {
 	public ItemFillerUpgrade() {
-		super("FillerUpgrade", -1);
+		super("FillerUpgrade", UpgradeType.FILLER);
 		this.setTextureName(Ref.MODID+":Filler_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemIronUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemIronUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -6,6 +6,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemIronUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemIronUpgrade.java
@@ -9,12 +9,13 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 
-public class ItemIronUpgrade extends ItemUpgrade {
+public class ItemIronUpgrade extends ItemTieredUpgrade {
 	public ItemIronUpgrade() {
-		super("IronUpgrade", ToolHelper.LEVEL_IRON);
+		super("IronUpgrade", UpgradeType.IRON, ToolHelper.LEVEL_IRON);
 		this.setTextureName(Ref.MODID+":Iron_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemStoneUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemStoneUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -6,6 +6,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
 

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemStoneUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemStoneUpgrade.java
@@ -9,12 +9,13 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 
-public class ItemStoneUpgrade extends ItemUpgrade {
+public class ItemStoneUpgrade extends ItemTieredUpgrade {
 	public ItemStoneUpgrade() {
-		super("StoneUpgrade", ToolHelper.LEVEL_STONE);
+		super("StoneUpgrade", UpgradeType.STONE, ToolHelper.LEVEL_STONE);
 		this.setTextureName(Ref.MODID+":Stone_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemTieredUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemTieredUpgrade.java
@@ -1,0 +1,34 @@
+package com.vanhal.progressiveautomation.items.upgrades;
+
+import com.vanhal.progressiveautomation.upgrades.UpgradeRegistry;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.item.Item;
+
+public abstract class ItemTieredUpgrade extends ItemUpgrade {
+	
+	private final int level;
+	
+	public ItemTieredUpgrade(String name, UpgradeType type, int level) {
+		super(name, type);
+		this.level = level;
+	}
+	
+	public void preInit(Item previousTier) {
+		GameRegistry.registerItem(this, itemName);
+		UpgradeRegistry.registerUpgradeItem(this.getType(), this);
+		addTieredRecipe(previousTier);
+	}
+	
+	protected abstract void addTieredRecipe(Item previousTier);
+	
+	public int getLevel() {
+		return level;
+	}
+
+	@Override
+	public int allowedAmount() {
+		return Integer.MAX_VALUE;
+	}
+}

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemUpgrade.java
@@ -1,6 +1,7 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
+import com.vanhal.progressiveautomation.items.BaseItem;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.init.Items;

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemUpgrade.java
@@ -2,6 +2,8 @@ package com.vanhal.progressiveautomation.items.upgrades;
 
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
 import com.vanhal.progressiveautomation.items.BaseItem;
+import com.vanhal.progressiveautomation.upgrades.UpgradeRegistry;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.init.Items;
@@ -9,32 +11,23 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-public class ItemUpgrade extends BaseItem {
-	public int level;
+public abstract class ItemUpgrade extends BaseItem {
+	private UpgradeType type;
 	
-	public ItemUpgrade() {
-		
-	}
-	
-	public ItemUpgrade(String name, int setLevel) {
+	public ItemUpgrade(String name, UpgradeType type) {
 		super(name);
-		setLevel(setLevel);
+		this.type = type;
 	}
 	
-	public void setLevel(int useLevel) {
-		level = useLevel;
+	public UpgradeType getType() {
+		return type;
 	}
-	
-	public int getLevel() {
-		return level;
+
+	public int allowedAmount() { return 1; }
+
+	@Override
+	public void preInit() {
+		super.preInit();
+		UpgradeRegistry.registerUpgradeItem(this.getType(), this);
 	}
-	
-	public void preInit(Item previousTier) {
-		GameRegistry.registerItem(this, itemName);
-		addTieredRecipe(previousTier);
-	}
-	
-	protected void addTieredRecipe(Item previousTier) {
-	}
-	
 }

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWitherUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWitherUpgrade.java
@@ -14,6 +14,7 @@ import com.vanhal.progressiveautomation.PAConfig;
 import com.vanhal.progressiveautomation.blocks.PABlocks;
 import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
@@ -21,7 +22,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemWitherUpgrade extends ItemUpgrade {
 	public ItemWitherUpgrade() {
-		super("WitherUpgrade", -1);
+		super("WitherUpgrade", UpgradeType.WITHER);
 		this.setTextureName(Ref.MODID+":Wither_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWitherUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWitherUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import java.util.List;
 
@@ -12,6 +12,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 
 import com.vanhal.progressiveautomation.PAConfig;
 import com.vanhal.progressiveautomation.blocks.PABlocks;
+import com.vanhal.progressiveautomation.items.PAItems;
 import com.vanhal.progressiveautomation.ref.Ref;
 
 import cpw.mods.fml.common.registry.GameRegistry;

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWoodUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWoodUpgrade.java
@@ -8,13 +8,14 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 
 import com.vanhal.progressiveautomation.ref.Ref;
 import com.vanhal.progressiveautomation.ref.ToolHelper;
+import com.vanhal.progressiveautomation.upgrades.UpgradeType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 
-public class ItemWoodUpgrade extends ItemUpgrade {
+public class ItemWoodUpgrade extends ItemTieredUpgrade {
 	
 	public ItemWoodUpgrade() {
-		super("WoodUpgrade", ToolHelper.LEVEL_WOOD);
+		super("WoodUpgrade", UpgradeType.WOODEN, ToolHelper.LEVEL_WOOD);
 		this.setTextureName(Ref.MODID+":Wood_Upgrade");
 	}
 	

--- a/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWoodUpgrade.java
+++ b/src/main/java/com/vanhal/progressiveautomation/items/upgrades/ItemWoodUpgrade.java
@@ -1,4 +1,4 @@
-package com.vanhal.progressiveautomation.items;
+package com.vanhal.progressiveautomation.items.upgrades;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;

--- a/src/main/java/com/vanhal/progressiveautomation/ref/ToolHelper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/ref/ToolHelper.java
@@ -30,11 +30,11 @@ public class ToolHelper {
 	public static int TYPE_HOE = 4;
 
 	//levels
-	public static int LEVEL_WOOD = 0;
-	public static int LEVEL_STONE = 1;
-	public static int LEVEL_IRON = 2;
-	public static int LEVEL_GOLD = 0;
-	public static int LEVEL_DIAMOND =3;
+	public static final int LEVEL_WOOD = 0;
+	public static final int LEVEL_STONE = 1;
+	public static final int LEVEL_IRON = 2;
+	public static final int LEVEL_GOLD = 0;
+	public static final int LEVEL_DIAMOND =3;
 	
 	//speeds for levels
 	public static int SPEED_WOOD = 2;

--- a/src/main/java/com/vanhal/progressiveautomation/upgrades/UpgradeRegistry.java
+++ b/src/main/java/com/vanhal/progressiveautomation/upgrades/UpgradeRegistry.java
@@ -1,0 +1,32 @@
+package com.vanhal.progressiveautomation.upgrades;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.vanhal.progressiveautomation.items.upgrades.ItemTieredUpgrade;
+import com.vanhal.progressiveautomation.items.upgrades.ItemUpgrade;
+
+public class UpgradeRegistry {
+
+	private static Map<UpgradeType, ItemUpgrade> upgradesMap = new EnumMap<UpgradeType, ItemUpgrade>(UpgradeType.class);
+	
+	/**
+	 * Register an upgrade item for the purposes of dropping machine contents on block destruction
+	 * @param type type of upgrade
+	 * @param item the item corresponding to the upgrade
+	 */
+	public static void registerUpgradeItem(UpgradeType type, ItemUpgrade item) {
+		upgradesMap.put(type, item);
+	}
+	
+	/**
+	 * @param type type of upgrade
+	 * @param level machine level
+	 * @return Item corresponding to the given type. If the upgrade is tiered, it will return
+	 * the version appropriate to the given level.
+	 */
+	public static ItemUpgrade getUpgradeItem(UpgradeType type) {
+			return upgradesMap.get(type);
+	}
+}

--- a/src/main/java/com/vanhal/progressiveautomation/upgrades/UpgradeType.java
+++ b/src/main/java/com/vanhal/progressiveautomation/upgrades/UpgradeType.java
@@ -1,0 +1,33 @@
+package com.vanhal.progressiveautomation.upgrades;
+
+import com.vanhal.progressiveautomation.ref.ToolHelper;
+
+/**
+ * This enum represents available upgrade types. Do NOT change the upgrade names without thought,
+ * it may cause players to lose installed upgrades in their machines
+ */
+public enum UpgradeType {
+
+	WOODEN,
+	STONE,
+	IRON,
+	DIAMOND,
+	WITHER,
+	COBBLE_GEN,
+	FILLER;
+
+	/**
+	 * Helper method for retrieving the proper range upgrade given the machineLevel
+	 * @param machineLevel
+	 * @return
+	 */
+	public static UpgradeType getRangeUpgrade(int machineLevel) {
+		switch (machineLevel) {
+			case ToolHelper.LEVEL_WOOD : return WOODEN;
+			case ToolHelper.LEVEL_STONE : return STONE;
+			case ToolHelper.LEVEL_IRON : return IRON;
+			case ToolHelper.LEVEL_DIAMOND : return DIAMOND;
+			default : return WOODEN;
+		}
+	}
+}


### PR DESCRIPTION
Better late than never, I guess.. Sorry again for such a delay.

In the new system, to add a new upgrade you'll have to:
- Add a new value to enum UpgradeType,
- Make a new ItemUpgrade with a method getType returning the previously mentioned value
- Add the value to setAllowedUpgrades inside a TE's constructor.

Optionally you can override ItemUpgrade#allowedAmount() to change the maximum amount of upgrades of that type you can put into a single machine (default = 1, MAX_INT for range upgrades)

Additionally I've edited BaseBlock#dismantleBlock and public class ItemBlockMachine#placeBlockAt
so they use read/write NBT methods from BaseTileEntity
