### PR TITLE
Added support for Power Advantage electricity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,10 @@ buildscript {
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
     }
 }
-ENV = System.getenv()
+def ENV = System.getenv()
 
 ext.configFile = file "build.properties"
+
 
 configFile.withReader {
     // read config. it shall from now on be referenced as simply config or as project.config
@@ -30,6 +31,10 @@ apply plugin: 'forge'
 version = config.mod_version + "." + config.buildNum
 group= "com.vanhal.progressiveautomation" 
 archivesBaseName = "ProgressiveAutomation-" + config.minecraft_version
+
+jar {
+    exclude('cyano/**')
+}
 
 minecraft {
     version = config.minecraft_version + "-" + config.forge_version

--- a/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
+++ b/src/main/java/com/vanhal/progressiveautomation/blocks/BaseBlock.java
@@ -160,6 +160,42 @@ public class BaseBlock extends BlockContainer implements IDismantleable {
 			Minecraft.getMinecraft().getRenderItem().getItemModelMesher()
 				.register(Item.getItemFromBlock(this), 0, new ModelResourceLocation(Ref.MODID + ":" + name, "inventory"));
 		}
+		if(net.minecraftforge.fml.common.Loader.isModLoaded("poweradvantage")){
+			cyano.poweradvantage.api.modsupport.LightWeightPowerRegistry.registerLightWeightPowerAcceptor(this, 
+					new cyano.poweradvantage.api.modsupport.ILightWeightPowerAcceptor(){
+
+				public boolean canAcceptEnergyType(cyano.poweradvantage.api.ConduitType powerType) {
+					return cyano.poweradvantage.api.ConduitType.areSameType(powerType, "electricity");
+				}
+
+				public float getEnergyDemand(TileEntity yourMachine,
+						cyano.poweradvantage.api.ConduitType powerType) {
+					if(yourMachine instanceof cofh.api.energy.IEnergyReceiver) {
+						cofh.api.energy.IEnergyReceiver m = (cofh.api.energy.IEnergyReceiver)yourMachine;
+						for(EnumFacing dir : EnumFacing.values()){
+							if(m.canConnectEnergy(dir)){
+								return m.getMaxEnergyStored(dir) - m.getEnergyStored(dir);
+							}
+						}
+					}
+					return 0;
+				}
+
+				public float addEnergy(TileEntity yourMachine,
+						float amountAdded, cyano.poweradvantage.api.ConduitType powerType) {
+					if(yourMachine instanceof cofh.api.energy.IEnergyReceiver) {
+						cofh.api.energy.IEnergyReceiver m = (cofh.api.energy.IEnergyReceiver)yourMachine;
+						for(EnumFacing dir : EnumFacing.values()){
+							if(m.canConnectEnergy(dir)){
+								return m.receiveEnergy(dir, (int)amountAdded, false);
+							}
+						}
+					}
+					return 0;
+				}
+
+			});
+		}
 	}
 	
 	protected ArrayList<ItemStack> getInsides(World world, BlockPos pos) {

--- a/src/main/java/cyano/poweradvantage/api/ConduitType.java
+++ b/src/main/java/cyano/poweradvantage/api/ConduitType.java
@@ -1,0 +1,121 @@
+package cyano.poweradvantage.api;
+
+import java.util.Locale;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.IBlockAccess;
+import cyano.poweradvantage.api.modsupport.LightWeightPowerRegistry;
+
+/**
+ * This class is used to identify different types of power (or other transport). It is optimized for 
+ * high-performance type-comparisons, especially if you use the 
+ * <b>areSameType(ConduitType a, ConduitType b)</b> static function.
+ * @author DrCyano
+ *
+ */
+
+///// MOCK CLASS! DO NOT INCLUDE IN JAR /////
+public class ConduitType {
+
+	/** type identifier */
+	private final String type;
+	/** cached hash-code for high-performance type checking */
+	private final long hashCache;
+	/**
+	 * Constructor for ConduitType. The type of a conductor is described by a simple string, such as 
+	 * "steam" or "electricity" or "fluid". Convention is to use the noun that describes what is 
+	 * moving from the source to the destination. Note that names with identical hashCodes will be 
+	 * behave as being the same type (this is a side-effect of performance optimizations).
+	 * @param name The name of this power type.
+	 */
+	public ConduitType(String name){
+		type = name.toLowerCase(Locale.US);
+		// MOCK
+		hashCache = type.hashCode();
+	}
+	
+	/**
+	 * Faster hash-code implementation that relies on cached value
+	 */
+	@Override
+	public int hashCode(){
+		return (int)hashCache;
+	}
+	/**
+	 * High-performance equals (fast response for un-equal values) that 
+	 * relies on cached hash-codes
+	 */
+	@Override
+	public boolean equals(Object o){
+		if(o == null) return false;
+		if(this == o) return true;
+		if(this.hashCode() == o.hashCode()){ // optimization with cached hashCodes
+			if(o instanceof ConduitType){
+				return areSameType(this,(ConduitType)o);
+			}
+		}
+		return false;
+	}
+	/**
+	 * High-performance convenience method for comparing conductor types
+	 * @param a a PowerConductorInstance
+	 * @param b another PowerConductorInstance
+	 * @return true if both are the same type of power conductor, false 
+	 * otherwise
+	 */
+	public static boolean areSameType(ConduitType a, ConduitType b){
+		return a.hashCache == b.hashCache;
+	}
+	
+
+	/**
+	 * High-performance convenience method for comparing conductor types
+	 * @param a a PowerConductorInstance
+	 * @param b the name of an energy type (e.g. "electricity" or "steam")
+	 * @return true if both are the same type of power conductor, false 
+	 * otherwise
+	 */
+	public static boolean areSameType(ConduitType a, String b){
+		// MOCK
+		return a.type.equals(b);
+	}
+	/**
+	 * Returns the energy type name
+	 * @return the energy type name
+	 */
+	@Override
+	public String toString(){
+		return type;
+	}
+	
+	/**
+	 * Determines whether a conduit block can interact with a neighboring (conduit) block 
+	 * @param w The World instance
+	 * @param B1 The block in question
+	 * @param faceOnB1 The neighboring block, specified by direction
+	 * @return Returns true if either the given block or its neighbor can accept the type of the 
+	 * other block
+	 */
+	public static boolean areConnectable(IBlockAccess w, BlockPos B1, EnumFacing faceOnB1){
+		Block a1 = w.getBlockState(B1).getBlock();
+		Block a2 = w.getBlockState(B1.offset(faceOnB1)).getBlock();
+		// MOCK
+		return areConnectable(a1,faceOnB1,a2);
+	}
+	/**
+	 * Determines whether a conduit block can interact with a neighboring (conduit) block 
+	 * @param a1 The block in question
+	 * @param faceOnB1 The direction to the neighboring block (from B1)
+	 * @param a2 The neighbor of the block in question
+	 * @return Returns true if either the given block or its neighbor can accept the type of the 
+	 * other block
+	 */
+	public static boolean areConnectable( Block a1, EnumFacing faceOnB1,  Block a2){
+		if(a1 instanceof ITypedConduit && a2 instanceof ITypedConduit){
+			return ((ITypedConduit)a1).canAcceptType(((ITypedConduit)a2).getType(), faceOnB1) || ((ITypedConduit)a2).canAcceptType(((ITypedConduit)a1).getType(), faceOnB1.getOpposite());
+		}
+		return false;
+	}
+}

--- a/src/main/java/cyano/poweradvantage/api/ITypedConduit.java
+++ b/src/main/java/cyano/poweradvantage/api/ITypedConduit.java
@@ -1,0 +1,48 @@
+package cyano.poweradvantage.api;
+
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Implement this method in every TileEntity and Block that interacts with energy. 
+ * This ensures that all relevant Blocks and TileEntities can check the energy 
+ * type of a Blocks or TileEntity. 
+ * @author DrCyano
+ *
+ */
+public interface ITypedConduit {
+	/**
+	 * Determines whether this conduit is compatible with an adjacent one
+	 * @param type The type of energy in the conduit
+	 * @param blockFace The side through-which the energy is flowing
+	 * @return true if this conduit can flow the given energy type through the given face, false 
+	 * otherwise
+	 */
+	public abstract boolean canAcceptType(ConduitType type, EnumFacing blockFace);
+	/**
+	 * Determines whether this conduit is compatible with a type of energy through any side
+	 * @param type The type of energy in the conduit
+	 * @return true if this conduit can flow the given energy type through one or more of its block 
+	 * faces, false otherwise
+	 */
+	public abstract boolean canAcceptType(ConduitType type);
+	
+	/**
+	 * Gets the energy type of this conduit. Most conduits can only interact 
+	 * with other conduits of the same type. 
+	 * @return The energy type of this conduit
+	 */
+	public abstract ConduitType getType();
+	/**
+	 * Determines whether this block/entity should receive energy. If this is not a sink, then it 
+	 * will never be given power by a power source. 
+	 * @return true if this block/entity should receive energy
+	 */
+	public abstract boolean isPowerSink();
+	/**
+	 * Determines whether this block/entity can provide energy. 
+	 * @return true if this block/entity can provide energy
+	 */
+	public abstract boolean isPowerSource();
+	
+
+}

--- a/src/main/java/cyano/poweradvantage/api/modsupport/ILightWeightPowerAcceptor.java
+++ b/src/main/java/cyano/poweradvantage/api/modsupport/ILightWeightPowerAcceptor.java
@@ -1,0 +1,45 @@
+package cyano.poweradvantage.api.modsupport;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import cyano.poweradvantage.api.ConduitType;
+
+/**
+ * This interface is used in the LightWeightPowerRegistry to allow established mods to optionally 
+ * support receiving power from Power Advantage power sources. This interface is usually 
+ * instantiated as an anonymous inner class rather than making a class implement it directly.
+ * @author DrCyano
+ *
+ */
+public interface ILightWeightPowerAcceptor {
+
+	/**
+	 * Used to determine which types of energy are acceptable
+	 * @param powerType A type of energy that you may or may not want to use as power
+	 * @return True if you accept this type, false if you reject it.
+	 */
+	public abstract boolean canAcceptEnergyType(ConduitType powerType);
+	/**
+	 * This method will be called whenever your machine block is polled for power requests. The 
+	 * TileEntity of the block being polled will be passed in (so you can safely cast it to your 
+	 * native TileEntity class type) along with the type of power that is being offered. Your 
+	 * implementation should cast the TileEntity to your specific class type, then decide how much 
+	 * energy of the offered type that it wants, and then return that amount (or 0 if you don't want 
+	 * to accept the offered energy type). Note that if energy is given, then the 
+	 * addEnergy(TileEntity, float, ConduitType) method will be invoked.
+	 * @param yourMachine The TileEntity instance being polled for power
+	 * @param powerType The type of power being offered
+	 * @return How much energy of the provided type your TileEntity is willing to accept.
+	 */
+	public abstract float getEnergyDemand(TileEntity yourMachine, ConduitType powerType);
+	/**
+	 * This method is called when energy it being provided to your TileEntity. The implementation of 
+	 * this method should figure out what to do with the energy and return the amount of energy that 
+	 * was actually used.
+	 * @param yourMachine The TileEntity receiving power
+	 * @param amountAdded The amount of power provided
+	 * @param powerType The type of power provided
+	 * @return The actual amount of power taken
+	 */
+	public abstract float addEnergy(TileEntity yourMachine, float amountAdded, ConduitType powerType);
+}

--- a/src/main/java/cyano/poweradvantage/api/modsupport/LightWeightPowerRegistry.java
+++ b/src/main/java/cyano/poweradvantage/api/modsupport/LightWeightPowerRegistry.java
@@ -1,0 +1,66 @@
+package cyano.poweradvantage.api.modsupport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+import cyano.poweradvantage.api.ConduitType;
+import cyano.poweradvantage.api.ITypedConduit;
+
+/**
+ * <p>This class provides a place to register blocks from other mods as power consumers. Such mods are 
+ * considered "external" power systems because their power implementation is not controlled by Power 
+ * Advantage. </p>
+ * <p>For example, you can add Power Advantage compatibility to an existing mod like this:</p><pre>
+	if(Loader.isModLoaded("poweradvantage")){
+		LightWeightPowerRegistry.registerLightWeightPowerAcceptor(Blocks.myMachine, 
+				new ILightWeightPowerAcceptor(){
+
+					public boolean canAcceptEnergyType(ConduitType powerType) {
+						return ConduitType.areSameType(powerType, "steam") || ConduitType.areSameType(powerType, "electricity");
+					}
+
+					public float getEnergyDemand(TileEntity yourMachine,
+							ConduitType powerType) {
+						TileEntityMyMachine m = (TileEntityMyMachine)yourMachine;
+						return m.getMaxEnergyStored() - m.getEnergyStored();
+					}
+
+					public float addEnergy(TileEntity yourMachine,
+							float amountAdded, ConduitType powerType) {
+						TileEntityMyMachine m = (TileEntityMyMachine)yourMachine;
+						return m.receiveEnergy(amountAdded,true);
+					}
+			
+		});
+	}
+</pre>
+ * @author DrCyano
+ *
+ */
+
+///// MOCK CLASS! EXCLUDE FROM JAR /////
+public class LightWeightPowerRegistry {
+
+	/**
+	 * Registers a block (and its associated TileEntity) as being able to receive power from the 
+	 * Power Advantage power sources in spite of not extending the Power Advantage classes.
+	 * @param machineBlock The block that has a machine that you want to receive power
+	 * @param powerAcceptorImplementation Implemetnation of ILightWeightPowerAcceptor that allows 
+	 * Power Advantage to ask the TileEntity associated with the given block how much power it wants 
+	 * and how to add power to that TileEntity
+	 */
+	public static void registerLightWeightPowerAcceptor(Block machineBlock, ILightWeightPowerAcceptor powerAcceptorImplementation){
+		// MOCK
+	}
+	
+	
+}

--- a/src/main/java/cyano/poweradvantage/api/modsupport/package-info.java
+++ b/src/main/java/cyano/poweradvantage/api/modsupport/package-info.java
@@ -1,0 +1,31 @@
+/**
+This package contains the light-weight API for people interested in adding Power Advantage support 
+to existing mods (instead of making a Power Advantage add-on mod). Typically, you achieve this be 
+first checking whether Power Advantage exists with <code>if(Loader.isModLoaded("poweradvantage")){ ... }</code>. 
+Then if you detect that Power Advantage is installed, you can add an ad-hoc power handler for each 
+of your machines like this:<br><pre>
+LightWeightPowerRegistry.registerLightWeightPowerAcceptor(Blocks.myMachine, 
+	new ILightWeightPowerAcceptor(){
+
+		public boolean canAcceptEnergyType(ConduitType powerType) {
+			return ConduitType.areSameType(powerType, "steam") || ConduitType.areSameType(powerType, "electricity");
+		}
+
+		public float getEnergyDemand(TileEntity yourMachine,
+				ConduitType powerType) {
+			TileEntityMyMachine m = (TileEntityMyMachine)yourMachine;
+			return m.getMaxEnergyStored() - m.getEnergyStored();
+		}
+
+		public float addEnergy(TileEntity yourMachine,
+				float amountAdded, ConduitType powerType) {
+			TileEntityMyMachine m = (TileEntityMyMachine)yourMachine;
+			return m.receiveEnergy(amountAdded,true);
+		}
+
+});
+</pre>
+The above example is for registerring a machine that should accept steam and electricity power from 
+Power Advantage add-on mods.
+*/
+package cyano.poweradvantage.api.modsupport;


### PR DESCRIPTION
Note that I had to make a small tweak to your build script to make it exclude the mock-up classes from the jar. The *net.minecraftforge.fml.common.Loader.isModLoaded("poweradvantage")* check should prevent runtime errors if Power Advantage is not installed on the client.