### PR TITLE
Attempt to solve issue #222

### DIFF
--- a/src/main/java/com/vanhal/progressiveautomation/compat/mods/ThaumCraft.java
+++ b/src/main/java/com/vanhal/progressiveautomation/compat/mods/ThaumCraft.java
@@ -4,6 +4,8 @@ import net.minecraft.item.ItemStack;
 
 import com.vanhal.progressiveautomation.ProgressiveAutomation;
 import com.vanhal.progressiveautomation.compat.BaseMod;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 
 public class ThaumCraft extends BaseMod {
 	
@@ -20,7 +22,14 @@ public class ThaumCraft extends BaseMod {
 	@Override
 	public boolean isLeaf(ItemStack item) {
 		if (item == null) return false;
-		return (item.getUnlocalizedName().contains("tile.blockMagicalLeaves"));
+		Boolean rv = false;
+		
+		try {
+			rv = item.getUnlocalizedName().contains("tile.blockMagicalLeaves");			
+		} catch(java.lang.NullPointerException e) {
+			ProgressiveAutomation.logger.warn("NullPointerException caught while calling ItemStack.getUnlocalizedName()");
+		}
+		return rv;
 	}
 	
 }

--- a/src/main/java/com/vanhal/progressiveautomation/compat/mods/ThaumCraft.java
+++ b/src/main/java/com/vanhal/progressiveautomation/compat/mods/ThaumCraft.java
@@ -16,20 +16,16 @@ public class ThaumCraft extends BaseMod {
 	@Override
 	public boolean isLog(ItemStack item) {
 		if (item == null) return false;
-		return (item.getUnlocalizedName().contains("tile.blockMagicalLog"));
+		// the item may be hiding in a delegate, so use getItem()
+		if (item.getItem() == null) return false;
+		return (item.getItem().getUnlocalizedName().contains("tile.blockMagicalLog"));
 	}
 	
 	@Override
 	public boolean isLeaf(ItemStack item) {
 		if (item == null) return false;
-		Boolean rv = false;
-		
-		try {
-			rv = item.getUnlocalizedName().contains("tile.blockMagicalLeaves");			
-		} catch(java.lang.NullPointerException e) {
-			ProgressiveAutomation.logger.warn("NullPointerException caught while calling ItemStack.getUnlocalizedName()");
-		}
-		return rv;
-	}
-	
+		// the item may be hiding in a delegate, so use getItem()
+		if (item.getItem() == null) return false;
+		return (item.getItem().getUnlocalizedName().contains("tile.blockMagicalLog"));
+	}	
 }


### PR DESCRIPTION
Somewhere along the way it seems the Item backing the ItemStack being handed to the code in the ThaumCraft helper is disappearing. This seems to happen between the test (at line 22) of the ItemStack not being null and the attempt to compare the result of ItemStack.getUnlocalizedName() to check for the leaf on line 23 of the existing source.

That this is happening at all indicates a bug in either Thaumcraft (I suspect this is true, as I'm getting other bugs from it or one of the integration mods that I have alongside it) or in the base Minecraft code. This attempts to patch the issue by wrapping the call to ItemStack.getUnlocalizedName() in a try-catch designed to catch the null-pointer deref exception.