### PR TITLE
Two new configuration options to resolve issues #271 and #141.

### DIFF
--- a/src/main/java/com/vanhal/progressiveautomation/PAConfig.java
+++ b/src/main/java/com/vanhal/progressiveautomation/PAConfig.java
@@ -50,6 +50,8 @@ public class PAConfig {
 	public static boolean allowWrench;
 	public static boolean destroyTools;
 	public static boolean shearTrees;
+	public static boolean allowInventoryOverflow;
+	public static boolean pauseOnFullInventory;
 	public static int maxRangeUpgrades;
 	
 	//machine levels
@@ -107,6 +109,8 @@ public class PAConfig {
 		allowWrench = config.getBoolean("allowWrench", "general", true, "Allows the wrench, you've got to be seriously evil to not allow this!");
 		destroyTools = config.getBoolean("destroyTools", "general", true, "Changing to false will make the machines spit a fully broken vanilla tool into it's inventory");
 		shearTrees = config.getBoolean("shearTrees", "general", true, "Allow the chopper to take a shearing upgrade in order to have a sheer to shear leaves");
+		allowInventoryOverflow = config.getBoolean("allowInventoryOverflow", "general", true, "Drop items on the ground if machine's inventory is full, setting this to false will destroy overflow items.");
+		pauseOnFullInventory = config.getBoolean("pauseOnFullInventory",  "general",  false, "Pause machines when the are no open slots in their inventory.");
 
 		
 		//enable blocks		

--- a/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/chopper/TileChopper.java
@@ -158,6 +158,9 @@ public class TileChopper extends UpgradeableTileEntity {
 		if (!worldObj.isRemote) {
 			checkForChanges();
 			checkInventory();
+			
+			// Pause if we're full and told to
+			if (isFull()) return;
 
 			if (isBurning()) {
 				if (chopping && blockList.size() == 0) {

--- a/src/main/java/com/vanhal/progressiveautomation/entities/farmer/TileFarmer.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/farmer/TileFarmer.java
@@ -254,6 +254,10 @@ public class TileFarmer extends UpgradeableTileEntity {
 		if (!worldObj.isRemote) {
 			doPickup();
 			checkInventory();
+
+			// Pause if we're full and told to
+			if (isFull()) return;
+
 			if (isBurning()) {
 				if (currentTime>0) {
 					currentTime--;

--- a/src/main/java/com/vanhal/progressiveautomation/entities/killer/TileKiller.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/killer/TileKiller.java
@@ -76,6 +76,10 @@ public class TileKiller extends UpgradeableTileEntity {
 		if (!worldObj.isRemote) {
 			doXpPickup();
 			checkInventory();
+			
+			// Pause if we're full and told to
+			if (isFull()) return;
+
 			if (isBurning()) {
 				if (currentTime>0) {
 					//count down the time between attacks

--- a/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/miner/TileMiner.java
@@ -66,6 +66,9 @@ public class TileMiner extends UpgradeableTileEntity {
 		if (!worldObj.isRemote) {
 			checkForChanges();
 			checkInventory();
+			
+			// If we're full, don't do anything else
+			if (isFull()) return;
 
 			if (isBurning()) {
 				useCobbleGen();

--- a/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanter.java
+++ b/src/main/java/com/vanhal/progressiveautomation/entities/planter/TilePlanter.java
@@ -51,6 +51,9 @@ public class TilePlanter extends UpgradeableTileEntity {
 		if (!worldObj.isRemote) {
 			checkInventory();
 
+			// Pause if we're full and told to
+			if (isFull()) return;
+
 			if (isBurning()) {
 				if (searchBlock > -1) {
 					if (currentTime>0) {

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIChopper.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIChopper.java
@@ -35,7 +35,9 @@ public class GUIChopper extends BaseGUI {
 			drawString(getTextLine(2, "gui.invalidtool.2"), infoScreenX, infoScreenW, infroScreenY2, ORANGE);
 		} else if (chopper.isLooked()) {
 			boolean readyToChop = false;
-			if ( (!chopper.hasFuel()) && (!chopper.isBurning()) ) {
+			if (chopper.isFull()) {
+				drawString(StringHelper.localize("gui.full"), infoScreenX, infoScreenW, infroScreenY2, RED);
+			} else if ( (!chopper.hasFuel()) && (!chopper.isBurning()) ) {
 				String fuelString = "gui.need.fuel";
 				if (chopper.hasEngine()) fuelString = "gui.need.energy";
 				drawString(StringHelper.localize(fuelString), infoScreenX, infoScreenW, infroScreenY2, RED);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIFarmer.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIFarmer.java
@@ -35,7 +35,9 @@ public class GUIFarmer extends BaseGUI {
 			drawString(getTextLine(2, "gui.invalidtool.2"), infoScreenX, infoScreenW, infroScreenY2, ORANGE);
 		} else if (farmer.isLooked()) {
 			boolean allGood = false;
-			if ( (!farmer.hasFuel()) && (!farmer.isBurning()) ) {
+			if (farmer.isFull()) {
+				drawString(StringHelper.localize("gui.full"), infoScreenX, infoScreenW, infroScreenY2, RED);
+			} else if ( (!farmer.hasFuel()) && (!farmer.isBurning()) ) {
 				String fuelString = "gui.need.fuel";
 				if (farmer.hasEngine()) fuelString = "gui.need.energy";
 				drawString(StringHelper.localize(fuelString), infoScreenX, infoScreenW, infroScreenY2, RED);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIKiller.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIKiller.java
@@ -36,7 +36,9 @@ public class GUIKiller extends BaseGUI {
 			drawString(getTextLine(2, "gui.invalidtool.2"), infoScreenX, infoScreenW, infroScreenY2, ORANGE);
 		} else if (killer.isLooked()) {
 			boolean readyToPlant = false;
-			if ( (!killer.hasFuel()) && (!killer.isBurning()) ) {
+			if (killer.isFull()) {
+				drawString(StringHelper.localize("gui.full"), infoScreenX, infoScreenW, infroScreenY2, RED);
+			} else if ( (!killer.hasFuel()) && (!killer.isBurning()) ) {
 				String fuelString = "gui.need.fuel";
 				if (killer.hasEngine()) fuelString = "gui.need.energy";
 				drawString(StringHelper.localize(fuelString), infoScreenX, infoScreenW, infroScreenY2, RED);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIMiner.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIMiner.java
@@ -34,7 +34,10 @@ public class GUIMiner extends BaseGUI {
 			drawString(getTextLine(2, "gui.invalidtool.2"), infoScreenX, infoScreenW, infroScreenY2, ORANGE);
 		} else if (miner.isLooked()) {
 			boolean readyToMine = true;
-			if ( (!miner.hasFuel()) && (!miner.isBurning()) ) {
+			if (miner.isFull()) {
+				drawString(StringHelper.localize("gui.full"), infoScreenX, infoScreenW, infroScreenY2, RED);
+				readyToMine = false;
+			} else if ( (!miner.hasFuel()) && (!miner.isBurning()) ) {
 				String fuelString = "gui.need.fuel";
 				if (miner.hasEngine()) fuelString = "gui.need.energy";
 				drawString(StringHelper.localize(fuelString), infoScreenX, infoScreenW, infroScreenY2, RED);

--- a/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIPlanter.java
+++ b/src/main/java/com/vanhal/progressiveautomation/gui/client/GUIPlanter.java
@@ -36,7 +36,9 @@ public class GUIPlanter extends BaseGUI {
 			drawString(getTextLine(2, "gui.invalidtool.2"), infoScreenX, infoScreenW, infroScreenY2, ORANGE);
 		} else if (planter.isLooked()) {
 			boolean readyToPlant = false;
-			if ( (!planter.hasFuel()) && (!planter.isBurning()) ) {
+			if (planter.isFull()) {
+				drawString(StringHelper.localize("gui.full"), infoScreenX, infoScreenW, infroScreenY2, RED);
+			} else if ( (!planter.hasFuel()) && (!planter.isBurning()) ) {
 				String fuelString = "gui.need.fuel";
 				if (planter.hasEngine()) fuelString = "gui.need.energy";
 				drawString(StringHelper.localize(fuelString), infoScreenX, infoScreenW, infroScreenY2, RED);


### PR DESCRIPTION
New configuration options:

pauseOnFullInventory (default: false)  If true, it will stop the Chopper, Farmer,
Killer, Miner or Planter when it has no vacant inventory slots.

allowInventoryOverflow (default: true) If true, it performs the current default
behaviour of dropping items into the world when the local inventory is
full.  Changing this setting to false will simply delete the overflow
items while allowing the machine to keep running.